### PR TITLE
#167280368-implement cancel trip functionality

### DIFF
--- a/server/controllers/trips.js
+++ b/server/controllers/trips.js
@@ -54,5 +54,20 @@ class Trips {
       });
     }
   }
+
+  static async updateTripStatus(req, res) {
+    try {
+      const updatedtrip = await tripHelperfunction.updateTripStatus(req.params.tripId);
+      return res.status(200).json({
+        status: 'success',
+        data: updatedtrip,
+      });
+    } catch (error) {
+      return res.status(404).json({
+        status: 'error',
+        message: error.message,
+      });
+    }
+  }
 }
 export default Trips;

--- a/server/routes/trips.js
+++ b/server/routes/trips.js
@@ -8,6 +8,7 @@ const router = express.Router();
 router.post('/', [validateTrip, validateToken, checkAdmin], Trip.createTrip);
 router.get('/', [validateToken], Trip.findAllTrips);
 router.get('/:tripId', [validateParam, validateToken], Trip.findATrip);
+router.patch('/:tripId', [validateParam, validateToken, checkAdmin], Trip.updateTripStatus);
 
 
 export default router;

--- a/server/test/trips.test.js
+++ b/server/test/trips.test.js
@@ -188,8 +188,8 @@ describe('trips', () => {
         .patch(`/api/v1/trips/${newTrip.trip_id}`)
         .set('token', `Bearer ${admin.token}`);
       assert.equal(res.status, 200, 'Success status should be 200');
-      assert.equal(res.body.data[0].status, 'cancelled', 'Trip status should be changed from active to cancelled');
-      assert.hasAnyKeys(res.body.data[0], ['trip_id', 'bus_id', 'trip_date'], 'The response object should conatin trip id, date, bus id');
+      assert.equal(res.body.data.status, 'cancelled', 'Trip status should be changed from active to cancelled');
+      assert.hasAnyKeys(res.body.data, ['trip_id', 'bus_id', 'trip_date'], 'The response object should conatin trip id, date, bus id');
     });
 
     it('Should return a 403 for a non admin user', async () => {

--- a/server/utils/trips.utils.js
+++ b/server/utils/trips.utils.js
@@ -64,5 +64,26 @@ class Trips {
     destination = destination.toUpperCase();
     return data.filter(item => item.destination === destination);
   }
+
+  static async updateTripStatus(id) {
+    try {
+      const trip = await Trips.findTrip(id);
+      if (!trip) {
+        throw new Error('Trip not found');
+      } else {
+        const newStatus = trip.status === 'active' ? 'cancelled' : 'active';
+        const updateTripQuery = 'UPDATE trips SET status=$1 WHERE trip_id=$2 returning *';
+        try {
+          const updatedTrip = await query(updateTripQuery, [newStatus, id]);
+          await Bus.updateBusAvailability(updatedTrip[0].bus_id);
+          return updatedTrip[0];
+        } catch (error) {
+          throw new Error('Could not update trip');
+        }
+      }
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  }
 }
 export default Trips;


### PR DESCRIPTION
#### What does this PR do?
Implements the cancel a trip functionality for admins

#### Description of Task to be completed?
Create endpoints to patch a trip by changing its status to active or canceled

#### How should this be manually tested?
one the repo, cd into the repo, run the command npm run devStart. Open Postman, create an admin account. Using the token generated in the request header make a post request to localhost:3000/api/v1/trips to create a trip. Then make a patch request to localhost:3000/api/v1/trips/:tripId
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#167280368](https://www.pivotaltracker.com/story/show/167280368)
#### Screenshots (if appropriate)
#### Questions